### PR TITLE
sticky menu/css update

### DIFF
--- a/app/static/styles/experiences.css
+++ b/app/static/styles/experiences.css
@@ -57,9 +57,10 @@ td {
 }
 
 .sectionClass {
-  padding: 80px 0px 50px 0px;
+  padding-top: 5vh;
   position: relative;
   display: block;
+  width: 80vw;
   /* background-color: #10a775; */
 }
 
@@ -110,14 +111,6 @@ td {
 /*  SECTION WORK EXPERIENCE
   ********************************/
 
-#work-experience {
-  position: absolute;
-  height: 100%;
-  width: 100%;
-  display: block-inline;
-
-  /* background-color: #10a775; */
-}
 #work-experience .sectiontitle .headerLine {
   width: 280px;
 }
@@ -393,8 +386,21 @@ td {
   }
 }
 
+/* ❗️this is a transperant div that overlays the nav bar and provides correct spacing for other content❗️ */
+.spacer {
+  display: flex;
+  height: 100vh;
+  width: 20vw;
+  max-width: 20vw;
+  min-width: 20vw;
+  margin: 0;
+
+  background-color: transparent;
+}
+
 .nav-bar {
   display: flex;
+  position: fixed;
   height: 100vh;
   width: 20vw;
   max-width: 20vw;

--- a/app/templates/experience.html
+++ b/app/templates/experience.html
@@ -22,6 +22,7 @@
 
 <body>
   <div class="overlayE"></div>
+
   <header class="nav-bar">
     <ul class="nav-content">
       <li class="nav-item">
@@ -49,6 +50,9 @@
       </li>
     </ul>
   </header>
+
+  <div class="spacer"></div>
+  <!-- spacer used for correct positioning -->
 
   <div id="workexperience" class="sectionClass">
     <div class="row">


### PR DESCRIPTION
# Description

This commit makes the menu bar sticky to handle when content extends past the bottom of the screen. 
This was accomplished by using position: "fixed"

Other CSS changes were also made. A spacer was added to overlay the menu bar to accommodate the old flex space that the new menu bar is no longer taking up due to position fixed. This spacer is very important. Its width has to be kept consistent with the width of the menu bar. This inconvenient but working fix can be rectified it there is a way for the position "fixed" menu bar's width to take up flex room. 

Education div was also adjusted to use vw and vh properties for padding and width so that it appears the same across all screen sizes. It is now centered and this resolves issue #24 

## Type of change
New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
Scrolling on the web page verifies that menu bar is now sticky. 
Applied background color to work experience div to verify that it is in the right position.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules